### PR TITLE
adicionado comando pra troca de avatar

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,6 @@
 {
     "token": "token.do.discord.aqui",
+    "prefixo": "!",
     "emoteBrabo": "😠",
     "emoteEnvergonhado": "😳"
 }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const config = require("./config.json");
 
 // Import the discord.js module
 const Discord = require('discord.js');
+const fetch = require('node-fetch');
 
 // Create an instance of a Discord client
 const client = new Discord.Client();
@@ -44,6 +45,56 @@ client.on('message', message => {
     if(message.author.bot) {
         console.log("recebida mensagem de um bot. Ignorando.")
         return;
+    }
+
+    // comandos que começam com o prefixo
+    if (message.content.startsWith(config.prefixo)) {
+
+        const args = message.content.slice(config.prefixo.length).trim().split(/ +/);
+        const command = args.shift().toLowerCase();
+
+        // comando pra trocar o avatar
+        // USO: !avatar <link>
+        if (command === 'avatar') {
+            
+            // verifica se a mensagem veio de um admin
+            if (message.member.hasPermission('ADMINISTRATOR')) {
+                // verifica se a mensagem tem um argumento
+                if (!args.length) {
+                    // se não tiver um argumento na mensagem
+                    console.error("\n\n:: [ERRO 1] Avatar: Usuário não enviou um argumento");
+                    return message.channel.send(`Trocar pra o que? Manda a foto, né, ${message.author}!`);
+                } else {
+                    // verifica se o link é uma imagem
+                    fetch(args[0])
+                        .then(res => {
+                            if (res.headers.get('content-type').startsWith('image')) {
+                                // é uma imagem!
+                                console.log(`\n\n :: [INFO] Alterando avatar para ${args[0]}`);
+                                // troca o avatar
+                                client.user.setAvatar(args[0]).catch((error) => {
+                                    console.error(`\n\n:: [ERRO 4] Avatar: Erro ao tentar trocar o avatar\n${error}\n\n`);
+                                    return message.reply(`Não consigo! <${config.emoteBrabo}>`);
+                                });
+                                return message.reply(`Trocando meu avatar! <${config.emoteEnvergonhado}>`);
+
+                            } else {
+                                console.error(`\n\n:: [ERRO 3] Avatar: Link não é uma imagem`);
+                                return message.reply(`Tem que ser uma imagem, né! <${config.emoteBrabo}>`);
+                            }
+                        })
+                        .catch((error) => {
+                            console.error(`\n\n:: [ERRO 2] Avatar: Argumento não é um link\n${error}\n\n`);
+                            return message.reply(`Tem que ser uma imagem, né! <${config.emoteBrabo}>`);
+                        });
+                }
+            } else {
+                console.log('\n\n:: [WARN 5] alguem tentou usar o comando de Avatar, mas não tem permissão de admin');
+                return message.reply(`Você não manda em mim!! <${config.emoteBrabo}>`);
+            }
+
+        }
+        return
     }
 
     // caso o bot leia "yoichi" no chat

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/saadbruno/yoichi-bot#readme",
   "dependencies": {
-    "discord.js": "^12.5.1"
+    "discord.js": "^12.5.1",
+    "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
Criado um comando no formato `!avatar <link>` que troca o avatar do bot.
Esse comando confere se o usuário que enviou o comando tem permissão de admin em qualquer um dos servidores autorizados no `config.json`.

![image](https://user-images.githubusercontent.com/23201434/114976053-b624a700-9e5b-11eb-8901-54c63fd03aee.png)
